### PR TITLE
Remove holdoff, power cap, and TRIAC control

### DIFF
--- a/src/gagguino.h
+++ b/src/gagguino.h
@@ -20,7 +20,7 @@ namespace gag {
  * @brief Initialize hardware, connectivity and discovery.
  *
  * Responsibilities:
- * - Configure pins and peripherals (MAX31865, ADC, TRIAC gate, etc.).
+ * - Configure pins and peripherals (MAX31865, ADC, etc.).
  * - Start Wi‑Fi and set MQTT parameters (but connection is retried in the main loop).
  * - Initialize Over‑The‑Air (OTA) update handling once Wi‑Fi is ready.
  * - Calibrate/zero pressure intercept on boot if near atmospheric.


### PR DESCRIPTION
## Summary
- eliminate warm-up holdoff, power capping, hysteresis, and TRIAC pump control
- document and code now focus solely on heater-based PID control
- ensure heater is shut off before WiFi or MQTT reconnection attempts to avoid overrun

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bedd2aa77c8330a7b175b009d957c7