### PR TITLE
Add MQTT OTA enable command with timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Getting Started
 - Optional OTA password:
   - In `platformio.ini` add build flag: `-D OTA_PASSWORD="your-password"` (or `OTA_PASSWORD_HASH`)
   - Match the `--auth` flag under `upload_flags` for `espota`.
+- Enable OTA via MQTT before uploading (opens a ~5 min window and pauses normal MQTT):
+  - `mosquitto_pub -h <broker> -t gaggia_classic/<UID>/ota/enable -n`
+  - Device resumes normal servicing when the update completes or the window expires.
 
 Home Assistant Integration
 --------------------------
@@ -75,6 +78,9 @@ mosquitto_pub -h <broker> -t gaggia_classic/<UID>/pid_guard/set -m 20.0
 # Heater ON/OFF
 mosquitto_pub -h <broker> -t gaggia_classic/<UID>/heater/set -m ON
 mosquitto_pub -h <broker> -t gaggia_classic/<UID>/heater/set -m OFF
+
+# Enable OTA window (~5 min)
+mosquitto_pub -h <broker> -t gaggia_classic/<UID>/ota/enable -n
 ```
 
 Tuning & Behavior


### PR DESCRIPTION
## Summary
- add `ota/enable` MQTT topic to trigger OTA mode
- automatically clear OTA mode after a 5 minute window
- document OTA enable command in README

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68bf05e36d68833091d7470aa9a77fe7